### PR TITLE
Add an ability to remove email through the api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ It allows manual testing in a web interface, and automated testing via an API.
 
 ## API
 
-Received mails are listed on `http://localhost:1080/api/emails`, and looks like this:a 
+#### Listing all received emails
+
+Received mails are listed on `http://localhost:1080/api/emails`, and looks like this:
 
 ```json
 [
@@ -55,6 +57,14 @@ Example:
 ```
     GET http://localhost:1080/api/emails?from=joe@example.com&to=bob@example.com&since=2017-09-18T12:00:00Z&until=2017-09-19T00:00:00Z
 ```
+
+#### Removing all received email
+
+To remove all emails without restarting the server:
+```
+    DELETE http://localhost:1080/api/emails
+``` 
+
 
 ## Web interface
 

--- a/index.js
+++ b/index.js
@@ -93,6 +93,11 @@ app.get('/api/emails', (req, res) => {
   res.json(mails.filter(emailFilter(req.query)));
 });
 
+app.delete('/api/emails', (req, res) => {
+    mails.length = 0;
+    res.send();
+});
+
 app.listen(config['http-port'], () => {
   cli.info("HTTP server listening on port " + config['http-port']);
 });


### PR DESCRIPTION
### The problem:
When `fake-smtp-server` is used for automated testing, restarting the server is the only way to remove all caught emails

### The solution:
This PR adds an additional end-point `DELETE /api/emails` which can be fetched between tests in order to delete all emails kept by the server.