### PR TITLE
Bugfix: Mail command failed: 421 Error: too many unauthenticated commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const mails = [];
 
 const server = new SMTPServer({
   authOptional: true,
+  maxAllowedUnauthenticatedCommands: 1000,
   onMailFrom(address, session, cb) {
     if (whitelist.length == 0 || whitelist.indexOf(address.address) !== -1) {
       cb();


### PR DESCRIPTION
This PR will fix the issue of too many unauthenticated commands while sending emails through automated test cases.