### PR TITLE
Hide TLS option for hiding TLS support in the feature list

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const config = cli.parse({
   whitelist: ['w', 'Only accept e-mails from these adresses. Accepts multiple e-mails comma-separated', 'string'],
   max: ['m', 'Max number of e-mails to keep', 'number', 100],
   auth: ['a', 'Enable Authentication', 'string'],
-  headers: [false, 'Enable headers in responses']
+  headers: [false, 'Enable headers in responses'],
+  hideTLS: [false, 'Hide TLS in feature list']
 });
 
 const whitelist = config.whitelist ? config.whitelist.split(',') : [];
@@ -36,6 +37,7 @@ const mails = [];
 
 const server = new SMTPServer({
   authOptional: true,
+  hideSTARTTLS: config.hideTLS,
   maxAllowedUnauthenticatedCommands: 1000,
   onMailFrom(address, session, cb) {
     if (whitelist.length == 0 || whitelist.indexOf(address.address) !== -1) {


### PR DESCRIPTION
Some SMTP client libraries automatically switch to TLS if the server announces TLS support. This PR adds the option for hiding TLS support in order to prevent that behavior. It could especially be useful for local testing.