### PR TITLE
Disable STARTTLS

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ if (config.auth) {
 const mails = [];
 
 const server = new SMTPServer({
+  disabledCommands: ['STARTTLS'],
   authOptional: true,
   maxAllowedUnauthenticatedCommands: 1000,
   onMailFrom(address, session, cb) {


### PR DESCRIPTION
It falsely advertises STARTTLS which doesn't work and breaks Symfony applications.

Related to https://github.com/maildev/maildev/issues/274 , https://github.com/symfony/symfony/pull/34172 and https://github.com/symfony/symfony/pull/34242