### PR TITLE
Update dependencies for NodeJS 18 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
   },
   "dependencies": {
     "cli": "1.0.1",
-    "express": "4.16.4",
-    "express-basic-auth": "1.1.6",
-    "lodash": "4.17.11",
-    "mailparser": "2.4.3",
-    "moment": "2.24.0",
-    "smtp-server": "3.5.0"
+    "express": "4.18.2",
+    "express-basic-auth": "1.2.1",
+    "lodash": "4.17.21",
+    "mailparser": "3.5.0",
+    "moment": "2.29.4",
+    "smtp-server": "3.11.0"
   },
   "devDependencies": {
-    "react": "16.8.3",
-    "react-dom": "16.8.3",
-    "react-scripts": "2.1.5",
-    "react-transition-group": "2.6.0",
-    "reactstrap": "7.1.0"
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-scripts": "5.0.1",
+    "react-transition-group": "4.4.5",
+    "reactstrap": "9.1.4"
   },
   "engines": {
     "node": ">=8.5.0"


### PR DESCRIPTION
This package did not work under NodeJS 18 because of incompatibilities in `smtp-server`. `Stream.Writable.closed` has become readonly. Updating package.json to update `smtp-server` has resolved this issue and maintain compatibility with older NodeJS versions.